### PR TITLE
Fixes a bug where a blob couldn't be matched against twice.

### DIFF
--- a/src/main/java/org/scassandra/cql/CqlBlob.java
+++ b/src/main/java/org/scassandra/cql/CqlBlob.java
@@ -19,6 +19,7 @@ public class CqlBlob extends PrimitiveType {
             ByteBuffer bb = (ByteBuffer) expected;
             byte[] b = new byte[bb.remaining()];
             bb.get(b);
+            bb.flip();
             String encodedExpected = Hex.encodeHexString(b);
             String actualWithout0x = actual.toString().replaceFirst("0x", "");
             return encodedExpected.equals(actualWithout0x);


### PR DESCRIPTION
The `ByteBuffer` `bb` here may be used multiple times.  The first time it is used, `bb` will correctly write out to the array `b`.  However, the second time it is used the buffer will already be fully read so `b` will be a zero length array with nothing in it.  By flipping the ByteBuffer after use, we are able to use it over and over again.

Fixes #1 
