### PR TITLE
[#3] Add support types added in protocol v3 and v4

### DIFF
--- a/src/main/antlr4/CqlTypes.g4
+++ b/src/main/antlr4/CqlTypes.g4
@@ -9,6 +9,7 @@ data_type
     | list_type
     | set_type
     | map_type
+    | tuple_type
     ;
 
 
@@ -18,14 +19,18 @@ native_type
     | 'blob'
     | 'boolean'
     | 'counter'
+    | 'date'
     | 'decimal'
     | 'double'
     | 'float'
     | 'inet'
     | 'int'
+    | 'smallint'
     | 'text'
+    | 'time'
     | 'timestamp'
     | 'timeuuid'
+    | 'tinyint'
     | 'uuid'
     | 'varchar'
     | 'varint'
@@ -41,4 +46,8 @@ set_type
 
 map_type
     : 'map' '<' native_type ',' native_type '>'
+    ;
+
+tuple_type
+    : 'tuple' '<' (native_type ',') + native_type '>'
     ;

--- a/src/main/java/org/scassandra/cql/CqlDate.java
+++ b/src/main/java/org/scassandra/cql/CqlDate.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlDate extends PrimitiveType {
+    CqlDate() {
+        super("date");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/src/main/java/org/scassandra/cql/CqlSmallInt.java
+++ b/src/main/java/org/scassandra/cql/CqlSmallInt.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlSmallInt extends PrimitiveType {
+    CqlSmallInt() {
+        super("smallint");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/src/main/java/org/scassandra/cql/CqlTime.java
+++ b/src/main/java/org/scassandra/cql/CqlTime.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlTime extends PrimitiveType {
+    public CqlTime() {
+        super("time");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/src/main/java/org/scassandra/cql/CqlTinyInt.java
+++ b/src/main/java/org/scassandra/cql/CqlTinyInt.java
@@ -1,0 +1,11 @@
+package org.scassandra.cql;
+
+public class CqlTinyInt extends PrimitiveType {
+    CqlTinyInt() {
+        super("tinyint");
+    }
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        return equalsForLongType(expected, actual, this);
+    }
+}

--- a/src/main/java/org/scassandra/cql/CqlTypeFactory.java
+++ b/src/main/java/org/scassandra/cql/CqlTypeFactory.java
@@ -8,6 +8,9 @@ import org.scassandra.antlr4.CqlTypesParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Stack;
 
 public class CqlTypeFactory {
@@ -95,6 +98,29 @@ public class CqlTypeFactory {
             CqlType value = inProgress.pop();
             inProgress.pop();
             this.cqlType = new ListType(value);
+        }
+
+        @Override
+        public void enterTuple_type(@NotNull CqlTypesParser.Tuple_typeContext ctx) {
+            this.inProgress.push(new TupleType(null));
+        }
+
+        @Override
+        public void exitTuple_type(@NotNull CqlTypesParser.Tuple_typeContext ctx) {
+            List<CqlType> types = new ArrayList<CqlType>();
+            while (true) {
+                CqlType type = inProgress.pop();
+                if(type instanceof TupleType) {
+                    if(((TupleType)type).getTypes() == null) {
+                        // Reverse list as stack is FILO.
+                        Collections.reverse(types);
+                        // encountered empty tuple, we know to stop.
+                        this.cqlType = new TupleType(types.toArray(new CqlType[types.size()]));
+                        break;
+                    }
+                }
+                types.add(type);
+            }
         }
 
         public CqlType getCqlType() {

--- a/src/main/java/org/scassandra/cql/PrimitiveType.java
+++ b/src/main/java/org/scassandra/cql/PrimitiveType.java
@@ -25,6 +25,10 @@ abstract public class PrimitiveType extends CqlType {
     public static final PrimitiveType BOOLEAN = registerPrimitive(new CqlBoolean());
     public static final PrimitiveType COUNTER = registerPrimitive(new CqlCounter());
     public static final PrimitiveType DECIMAL = registerPrimitive(new CqlDecimal());
+    public static final PrimitiveType DATE = registerPrimitive(new CqlDate());
+    public static final PrimitiveType SMALL_INT = registerPrimitive(new CqlSmallInt());
+    public static final PrimitiveType TIME = registerPrimitive(new CqlTime());
+    public static final PrimitiveType TINY_INT = registerPrimitive(new CqlTinyInt());
 
     private final String columnType;
 

--- a/src/main/java/org/scassandra/cql/TupleType.java
+++ b/src/main/java/org/scassandra/cql/TupleType.java
@@ -1,0 +1,78 @@
+package org.scassandra.cql;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TupleType extends CqlType {
+
+    private final CqlType[] types;
+
+    public static TupleType tuple(CqlType ... types) {
+        return new TupleType(types);
+    }
+
+    TupleType(CqlType ... types) {
+        this.types = types;
+    }
+
+    @Override
+    public String serialise() {
+        StringBuilder s = new StringBuilder("tuple<");
+        for(int i = 0; i < types.length; i++) {
+            CqlType type = types[i];
+            s.append(type.serialise());
+            if(i < types.length-1) {
+                s.append(",");
+            }
+        }
+        s.append(">");
+        return s.toString();
+    }
+
+    @Override
+    public boolean equals(Object expected, Object actual) {
+        if (expected == null) return actual == null;
+        if (actual == null) return false;
+
+        if (expected instanceof List) {
+            final List<?> typedExpected = (List<?>) expected;
+            final List<?> actualList = (List<?>) actual;
+
+            if (typedExpected.size() != actualList.size()) return false;
+
+            // expect exact elements
+            if (types == null || typedExpected.size() != types.length)
+                throw throwInvalidType(expected, actual, this);
+
+            for (int i = 0; i < actualList.size(); i++) {
+                CqlType type = types[i];
+                if (!type.equals(typedExpected.get(i), actualList.get(i))) return false;
+            }
+            return true;
+        } else {
+            throw throwInvalidType(expected, actual, this);
+        }
+    }
+
+
+
+    public CqlType[] getTypes() {
+        return types;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TupleType)) return false;
+
+        TupleType tupleType = (TupleType) o;
+
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        return Arrays.equals(types, tupleType.types);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(types);
+    }
+}

--- a/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
+++ b/src/test/java/org/scassandra/cql/CqlTypeFactoryTest.java
@@ -23,6 +23,7 @@ public class CqlTypeFactoryTest {
                 {"list<ascii>", new ListType(PrimitiveType.ASCII) },
                 {"list<boolean>", new ListType(PrimitiveType.BOOLEAN) },
                 {"list<decimal>", new ListType(PrimitiveType.DECIMAL) },
+                {"tuple<int,inet,date>", new TupleType(PrimitiveType.INT, PrimitiveType.INET, PrimitiveType.DATE)},
                 {"ascii", PrimitiveType.ASCII},
                 {"varchar", PrimitiveType.VARCHAR},
                 {"bigint", PrimitiveType.BIG_INT},
@@ -37,7 +38,11 @@ public class CqlTypeFactoryTest {
                 {"varint", PrimitiveType.VAR_INT},
                 {"timeuuid", PrimitiveType.TIMEUUID},
                 {"inet", PrimitiveType.INET},
-                {"text", PrimitiveType.TEXT}
+                {"text", PrimitiveType.TEXT},
+                {"date", PrimitiveType.DATE},
+                {"smallint", PrimitiveType.SMALL_INT},
+                {"time", PrimitiveType.TIME},
+                {"tinyint", PrimitiveType.TINY_INT}
         });
     }
 

--- a/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
+++ b/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
@@ -23,6 +23,7 @@ import static org.scassandra.cql.ListType.list;
 import static org.scassandra.cql.MapType.map;
 import static org.scassandra.cql.PrimitiveType.*;
 import static org.scassandra.cql.SetType.set;
+import static org.scassandra.cql.TupleType.tuple;
 
 @RunWith(Parameterized.class)
 public class CqlTypesEqualsTest {
@@ -205,6 +206,39 @@ public class CqlTypesEqualsTest {
                 {INET, 1, InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
                 {INET, new BigInteger("1"), InetAddress.getLocalHost().getHostAddress(), ILLEGAL_ARGUMENT},
 
+                {DATE, 1, "1", MATCH},
+                {DATE, 1, 1d, MATCH},
+                {DATE, "1", 1d, MATCH},
+                {DATE, new BigInteger("1"), 1d, MATCH},
+
+                {DATE, null, 1, NO_MATCH},
+                {DATE, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {TIME, 1, "1", MATCH},
+                {TIME, 1, 1d, MATCH},
+                {TIME, "1", 1d, MATCH},
+                {TIME, new BigInteger("1"), 1d, MATCH},
+
+                {TIME, null, 1, NO_MATCH},
+                {TIME, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {TINY_INT, 1, "1", MATCH},
+                {TINY_INT, 1, 1d, MATCH},
+                {TINY_INT, "1", 1d, MATCH},
+                {TINY_INT, new BigInteger("1"), 1d, MATCH},
+
+                {TINY_INT, null, 1, NO_MATCH},
+                {TINY_INT, "hello", 1d, ILLEGAL_ARGUMENT},
+
+                {SMALL_INT, 1, "1", MATCH},
+                {SMALL_INT, 1, 1d, MATCH},
+                {SMALL_INT, "1", 1d, MATCH},
+                {SMALL_INT, new BigInteger("1"), 1d, MATCH},
+
+                {SMALL_INT, null, 1, NO_MATCH},
+                {SMALL_INT, "hello", 1d, ILLEGAL_ARGUMENT},
+
+
                 {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("one"), MATCH},
                 {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("two"), NO_MATCH},
                 {new SetType(TEXT), Sets.newHashSet("one"), Lists.newArrayList("one", "two"), NO_MATCH},
@@ -275,6 +309,20 @@ public class CqlTypesEqualsTest {
                 {map(TEXT, TEXT), 1l, ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
                 {map(TEXT, TEXT), 1, ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
                 {map(TEXT, TEXT), new BigInteger("1"), ImmutableMap.of("ONE", "1"), ILLEGAL_ARGUMENT},
+
+                {tuple(TEXT, INT), Lists.newArrayList("one", 1), Lists.newArrayList("one", 1), MATCH},
+                {tuple(TEXT, INT), Lists.newArrayList("one", 1), Lists.newArrayList("two", 1), NO_MATCH},
+                {tuple(TEXT, INT), Lists.newArrayList("one", 1), Lists.newArrayList("one", 2), NO_MATCH},
+
+                {tuple(TEXT, INT), null, Lists.newArrayList("one", 1), NO_MATCH},
+                {tuple(TEXT, INT), Lists.newArrayList("one", 1), null, NO_MATCH},
+
+                {tuple(TEXT, INT), new Date(1l), Lists.newArrayList("one", 1), ILLEGAL_ARGUMENT},
+                {tuple(TEXT, INT), 1l, Lists.newArrayList("one", 1), ILLEGAL_ARGUMENT},
+                {tuple(TEXT, INT), 1, Lists.newArrayList("one", 1), ILLEGAL_ARGUMENT},
+                {tuple(TEXT, INT), new BigInteger("1"), Lists.newArrayList("one", 1), ILLEGAL_ARGUMENT},
+
+                {tuple(TEXT, INT), Lists.newArrayList("one"), Lists.newArrayList("one"), ILLEGAL_ARGUMENT},
         });
     }
 


### PR DESCRIPTION
Adds support for cql types added in protocol version 3 and 4:
- tuple (v3)
- date (v4)
- time (v4)
- smallint (v4)
- tinyint (v4)

Does not support UDTs, not quite sure how to handle this as it can't be represented in one line easily.  Think would be better to attack as a separate PR.

Perhaps date and time could be updated to support comparing iso dates/times in its equal methods, although that doesn't seem like a high priority.
