### PR TITLE
Long type comparison bug fix

### DIFF
--- a/src/main/java/org/scassandra/cql/PrimitiveType.java
+++ b/src/main/java/org/scassandra/cql/PrimitiveType.java
@@ -66,7 +66,7 @@ abstract public class PrimitiveType extends CqlType {
         if (expected instanceof Integer) {
             return ((Integer) expected).longValue() == typedActual;
         } else if (expected instanceof Long) {
-            return expected == typedActual;
+            return expected.equals(typedActual);
         } else if (expected instanceof BigInteger) {
             return expected.equals(new BigInteger(typedActual.toString()));
         } else if (expected instanceof String) {

--- a/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
+++ b/src/test/java/org/scassandra/cql/CqlTypesEqualsTest.java
@@ -56,6 +56,7 @@ public class CqlTypesEqualsTest {
                 {BIG_INT, 1, "1", MATCH},
                 {BIG_INT, 1, 1d, MATCH},
                 {BIG_INT, 1l, 1d, MATCH},
+                {BIG_INT, new Long("1"), new Long("1"), MATCH},
                 {BIG_INT, new BigInteger("1"), 1d, MATCH},
 
                 {BIG_INT, null, 1d, NO_MATCH},


### PR DESCRIPTION
Fixed an issue where boxed long types where being compared by memory reference instead of value.
